### PR TITLE
Fixed minor protection level issue

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -49,7 +49,7 @@ public enum PulleyPosition: Int {
     case partiallyRevealed = 1
     case open = 2
     
-    static var all: [PulleyPosition] = [
+    public static let all: [PulleyPosition] = [
         .collapsed,
         .partiallyRevealed,
         .open


### PR DESCRIPTION
The `PulleyPosition.all` shortcut was unavailable when Pulley is used as a framework, because the protection level used was the default, which is `internal`. Changing this to `public` makes it available outside of the framework so app view controllers can use it as shown in the example.

I also changed this to a let instead of a var, assuming there would be no reason to change what "all" means.